### PR TITLE
Updated spurious references to CloudOn in quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -59,8 +59,8 @@ This section provides information regarding the variables used in the template.
 
 | Variable      | Default        | Description                                                                                                                                                           |
 |---------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CreateNewUser | yes            | Create a new IAM user specific to Rubrik CloudOn. If 'no' is selected, the IAM policy will be attached to the provided `IAMUserName` which should already be created. |
-| IAMUserName   | rubrik-cloudon | The name of the IAM User to assign the new CloudOn specific policies to.                                                                                              |
+| CreateNewUser | yes            | Create a new IAM user specific to Rubrik cloudout. If 'no' is selected, the IAM policy will be attached to the provided `IAMUserName` which should already be created. |
+| IAMUserName   | rubrik-cloudout | The name of the IAM User to assign the new cloudout specific policies to.                                                                                              |
 
 ### Optional
 
@@ -68,7 +68,7 @@ Default names and descriptions for the various IAM Users, Policies, and Security
 
 | Variable       | Default        | Description                                 |
 |----------------|----------------|---------------------------------------------|
-| UserPolicyName | rubrik-cloudon | S3 Security policy used for Rubrik CloudOn. |
+| UserPolicyName | rubrik-cloudout | S3 Security policy used for Rubrik cloudout. |
 
 ## Output 
 


### PR DESCRIPTION
# Description

The quickstart referenced CloudOn which was not referenced in template

## Related Issue

Doc fix.

## Motivation and Context

It's fixing doc errors. 

## How Has This Been Tested?

It's a doc change. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
